### PR TITLE
feat(providers): add Codex CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to Novel Engine are documented here.
 
 ---
 
+## [2026-04-26] — Codex CLI provider support
+
+### Summary
+
+Added Codex CLI as a second built-in local tool-use provider alongside Claude Code CLI. The provider registry now registers a `codex-cli` backend, Settings can detect `codex --version`, model selection includes Codex models, and the new Codex runner translates `codex exec --json` output into Novel Engine stream events while tracking changed files.
+
+### Added
+- `src/infrastructure/codex-cli/CodexCliClient.ts` — Implements `IModelProvider` for `codex exec --json`, process aborts, JSONL parsing, event persistence, token usage capture, and changed-file detection.
+- `src/infrastructure/codex-cli/index.ts` — Exports the Codex CLI client module.
+
+### Changed
+- `src/domain/types.ts` — Added `codex-cli` to `ProviderType` and `hasCodexCli` to `AppSettings`.
+- `src/domain/interfaces.ts` — Added `ISettingsService.detectCodexCli()`.
+- `src/domain/constants.ts` — Added `CODEX_CLI_PROVIDER_ID` and Codex built-in provider models.
+- `src/infrastructure/settings/SettingsService.ts` — Added `codex --version` detection and built-in provider config merging for existing settings files.
+- `src/main/index.ts` — Instantiates and registers `CodexCliClient` as a built-in provider.
+- `src/main/ipc/handlers.ts` — Added `settings:detectCodexCli`.
+- `src/preload/index.ts` — Exposes `settings.detectCodexCli()` to the renderer.
+- `src/renderer/stores/settingsStore.ts` — Added Codex CLI detection action.
+- `src/renderer/components/Settings/SettingsView.tsx` — Added Codex CLI status card and Codex docs link.
+- `src/renderer/components/Settings/ProviderSection.tsx` — Labels `codex-cli` provider cards and describes both CLI providers.
+- `README.md` — Documents Codex CLI support, setup, provider selection, and source tree updates.
+- `docs/USER_GUIDE.md` — Documents Codex CLI setup and troubleshooting.
+- `docs/architecture/ARCHITECTURE.md` — Adds Codex CLI to stack, source tree, dependencies, and security notes.
+- `docs/architecture/DOMAIN.md` — Documents Codex provider types, settings, interfaces, and constants.
+- `docs/architecture/INFRASTRUCTURE.md` — Documents the new Codex CLI module and invocation.
+- `docs/architecture/IPC.md` — Documents `settings:detectCodexCli` and preload bridge shape.
+- `docs/architecture/RENDERER.md` — Documents settings store and Settings UI changes.
+
+### Architecture Impact
+- New infrastructure module: `src/infrastructure/codex-cli/`.
+- New built-in provider: `codex-cli`.
+- New IPC channel: `settings:detectCodexCli`.
+- New preload bridge method: `window.novelEngine.settings.detectCodexCli()`.
+- New settings field: `hasCodexCli`.
+
+### Migration Notes
+- Existing `settings.json` files are forward-merged with built-in provider configs on load so Codex CLI appears without deleting user providers.
+
+---
+
 ## [2026-03-29] — Architecture Engine readme
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A desktop application for **building novels**, not writing them. Novel Engine is
 
 You bring the story. The agents pitch, scaffold, draft in your voice, read, analyze, plan revisions, copy-edit, and compile your manuscript into export-ready formats. The pipeline is a build process: source material goes in, a production-ready manuscript comes out. "Build" is both metaphor and literal — the final phase assembles chapters via [Pandoc](https://pandoc.org/) into Markdown, DOCX, and EPUB.
 
-Built with Electron, React, TypeScript, and powered by the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) — with extensible multi-model provider support for OpenAI-compatible endpoints. No cloud backend. Everything runs on your machine.
+Built with Electron, React, TypeScript, and powered by local CLI providers: [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://developers.openai.com/codex/cli), and extensible OpenAI-compatible endpoints. No cloud backend. Everything runs on your machine.
 
 Requires tech skill to use — or grab a pre-built installer from [Releases](https://github.com/john-paul-ruf/novel-engine/releases) if one exists for your platform.
 
@@ -42,6 +42,7 @@ Requires tech skill to use — or grab a pre-built installer from [Releases](htt
 > - Does the installer run and complete without errors?
 > - Does the app launch after installation?
 > - Does the onboarding wizard detect your Claude Code CLI?
+> - If you use Codex, does Settings detect your Codex CLI?
 > - Can you create a book and chat with an agent?
 > - Any UI glitches, missing fonts, or broken layouts?
 
@@ -159,7 +160,7 @@ Every agent interaction assembles context intelligently using a token-budget-awa
 2. **Per-agent read guidance** — tells each agent which files are required, relevant, or irrelevant to their role
 3. **Dynamic conversation compaction** — calculates how much context window remains after the system prompt and response reserve, then keeps as many recent turns as the budget allows (generous: all turns, moderate: 8, tight: 4, critical: 2)
 
-Agents run in full **agent mode** with tool use — they read and write files directly in the book directory using Claude Code CLI's Read, Write, Edit, and LS tools.
+Agents run in full **agent mode** with tool use — they read and write files directly in the book directory through local CLI providers such as Claude Code CLI and Codex CLI.
 
 ### Auto-Draft
 
@@ -226,7 +227,7 @@ Features:
 
 ### Extended Thinking
 
-Enable **extended thinking** globally or override it per-message with the **thinking budget slider**. Each agent has a default thinking budget tuned to their task complexity. When enabled, the app passes `--effort high` to the Claude CLI. Thinking blocks are displayed in collapsible amber panels with auto-generated summaries (~200 characters).
+Enable **extended thinking** globally or override it per-message with the **thinking budget slider**. Each agent has a default thinking budget tuned to their task complexity. Claude CLI can surface thinking blocks in collapsible amber panels with auto-generated summaries (~200 characters); Codex CLI runs reasoning internally but does not expose Claude-style thinking text.
 
 ### Quick Actions
 
@@ -234,7 +235,7 @@ Each agent has pre-built prompts accessible from a dropdown next to the chat inp
 
 ### CLI Activity Monitor
 
-A real-time panel showing all active Claude CLI processes. Tracks every stream across the app — chat, auto-draft, hot takes, ad hoc revisions, revision queue sessions, audits, and motif audits. Each stream shows the agent name, progress stage (reading → thinking → drafting → editing → reviewing → complete), active tool use with file paths, and elapsed time. The panel persists across view changes.
+A real-time panel showing all active local CLI processes. Tracks every stream across the app — chat, auto-draft, hot takes, ad hoc revisions, revision queue sessions, audits, and motif audits. Each stream shows the agent name, progress stage (reading → thinking → drafting → editing → reviewing → complete), active tool use with file paths, and elapsed time. The panel persists across view changes.
 
 ### Modal Chat
 
@@ -271,7 +272,7 @@ When an agent finishes responding and the app window is not focused, Novel Engin
 
 ### Multi-Model Provider Support
 
-Beyond the built-in Claude Code CLI, Novel Engine supports **OpenAI-compatible endpoints** (e.g., Ollama, LM Studio, self-hosted models). Add providers in Settings with a base URL and optional API key. Each provider declares its capabilities (text-completion, tool-use, thinking, streaming) so the app gates features accordingly. A central provider registry routes model requests to the correct backend.
+Beyond the built-in Claude Code CLI and Codex CLI, Novel Engine supports **OpenAI-compatible endpoints** (e.g., Ollama, LM Studio, self-hosted models). Add providers in Settings with a base URL and optional API key. Each provider declares its capabilities (text-completion, tool-use, thinking, streaming) so the app gates features accordingly. A central provider registry routes model requests to the correct backend.
 
 ### Series Bible
 
@@ -387,6 +388,7 @@ View and edit book metadata (`about.json`) directly in the Files view — title,
 
 - **Node.js** 18+
 - **Claude Code CLI** — install via `npm install -g @anthropic-ai/claude-code`, then authenticate with `claude login`
+- **Codex CLI** (optional) — install via `npm i -g @openai/codex`, then authenticate with `codex login`
 - **Pandoc** (optional) — required for DOCX/EPUB export. Run `npm run download-pandoc` to fetch a platform-specific binary, or install separately
 
 ---
@@ -412,7 +414,7 @@ On first launch the **Onboarding Wizard** walks you through five steps:
 
 1. **Welcome** — introduction
 2. **Claude CLI Setup** — auto-detects the `claude` binary; links to install instructions if not found
-3. **Model Selection** — choose a default Claude model (Opus or Sonnet)
+3. **Model Selection** — choose a default model from enabled providers, including Claude and Codex models
 4. **Author Profile** — write or skip your creative DNA document
 5. **Ready** — creates your first book or enters the app
 
@@ -470,6 +472,9 @@ src/
 │   ├── claude-cli/
 │   │   ├── ClaudeCodeClient.ts          # Claude CLI wrapper, streaming, tool tracking
 │   │   ├── StreamSessionTracker.ts      # Progress stage inference, file touch tracking
+│   │   └── index.ts
+│   ├── codex-cli/
+│   │   ├── CodexCliClient.ts            # Codex CLI wrapper, JSONL streaming, changed-file tracking
 │   │   └── index.ts
 │   ├── providers/
 │   │   ├── ProviderRegistry.ts          # Central registry routing models to providers
@@ -693,7 +698,7 @@ Agent system prompts live in `custom-agents/` and are fully editable — customi
 | Styling | [Tailwind CSS](https://tailwindcss.com/) + [Typography plugin](https://github.com/tailwindlabs/tailwindcss-typography) | 4.x |
 | State | [Zustand](https://zustand-demo.pmnd.rs/) | 5.x |
 | Database | [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) | 11.x |
-| AI Backend | [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) + OpenAI-compatible endpoints | (spawned / fetched) |
+| AI Backend | [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) + [Codex CLI](https://developers.openai.com/codex/cli) + OpenAI-compatible endpoints | (spawned / fetched) |
 | Manuscript Export | [Pandoc](https://pandoc.org/) (bundled binary) | — |
 | Charts | [Recharts](https://recharts.org/) | 3.x |
 | Diffing | [diff](https://github.com/kpdecker/jsdiff) | 8.x |
@@ -713,7 +718,7 @@ DOMAIN ← INFRASTRUCTURE ← APPLICATION ← IPC/MAIN ← RENDERER
 ```
 
 - **Domain** ([`src/domain/`](./src/domain/)) — Pure TypeScript types, interfaces, and constants. Zero imports. Every other layer depends on this.
-- **Infrastructure** ([`src/infrastructure/`](./src/infrastructure/)) — Concrete implementations: SQLite database with forward-only migrations, filesystem I/O, Claude CLI wrapper, file watchers, Pandoc runner, settings persistence, provider registry with OpenAI-compatible support, series file-based storage.
+- **Infrastructure** ([`src/infrastructure/`](./src/infrastructure/)) — Concrete implementations: SQLite database with forward-only migrations, filesystem I/O, Claude CLI and Codex CLI wrappers, file watchers, Pandoc runner, settings persistence, provider registry with OpenAI-compatible support, series file-based storage.
 - **Application** ([`src/application/`](./src/application/)) — Business logic orchestrating infrastructure through injected interfaces: ChatService, ContextBuilder, PipelineService, BuildService, RevisionQueueService, AuditService, PitchRoomService, HotTakeService, AdhocRevisionService, StreamManager, MotifLedgerService, VersionService, ManuscriptImportService, SourceGenerationService, SeriesImportService, HelperService, DashboardService, StatisticsService, FindReplaceService, UsageService, ChapterValidator.
 - **Main/IPC** ([`src/main/`](./src/main/)) — Electron entry point (composition root), IPC handlers (thin one-liner delegations), first-run bootstrap, OS notifications.
 - **Renderer** ([`src/renderer/`](./src/renderer/)) — React components, Zustand stores (23 stores), hooks. Communicates with the backend exclusively through `window.novelEngine` (the preload bridge). May import domain types but never values.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,6 +1,6 @@
 # Novel Engine — User Guide
 
-> Last updated: 2026-03-28
+> Last updated: 2026-04-26
 
 ---
 
@@ -8,9 +8,9 @@
 
 Novel Engine is an Electron desktop application for writing novels with the help of 7 specialized AI agents. Each agent has a distinct role in the writing process — from pitching a story concept through drafting, revision, copy editing, and publication.
 
-The app uses the **Claude Code CLI** as its AI backend. You need a Claude subscription — Novel Engine doesn't store API keys or handle billing. The CLI authenticates through your own Anthropic account.
+The app uses local CLI providers as AI backends. Claude Code CLI and Codex CLI authenticate through their own accounts, and Novel Engine does not store API keys for those built-in CLI providers.
 
-All your books, chapters, and project files are stored locally on your machine in the app's user data directory. Nothing is sent to external servers beyond the Claude API calls made through the CLI.
+All your books, chapters, and project files are stored locally on your machine in the app's user data directory. AI prompts are sent through the provider you select in Settings.
 
 ---
 
@@ -20,11 +20,12 @@ All your books, chapters, and project files are stored locally on your machine i
 
 When you open Novel Engine for the first time, the **onboarding wizard** guides you through setup:
 
-1. **CLI Detection** — The app checks if the `claude` CLI is installed and authenticated. If not, you'll see instructions to install it.
+1. **CLI Detection** — The app checks if the `claude` CLI is installed and authenticated. Codex CLI can be detected later from Settings.
 2. **Author Name** — Enter your name (used in book metadata and cover pages).
 3. **Model Selection** — Choose your default model:
    - **Claude Opus 4** — Best quality, recommended for all creative work
    - **Claude Sonnet 4** — Faster and cheaper, good for copy editing and utility tasks
+   - **GPT-5.2 Codex** — Codex CLI option for local agentic tool-use workflows
 
 ### Creating Your First Book
 
@@ -415,7 +416,7 @@ Choose between **Light**, **Dark** (default), or **System** (follows OS preferen
 
 ### Provider Management
 
-Configure AI providers in the **Providers** section. Claude CLI is the built-in provider and cannot be removed.
+Configure AI providers in the **Providers** section. Claude CLI and Codex CLI are built-in providers and cannot be removed. Use **Re-check** on either CLI status card after installing or logging in.
 
 ### OS Notifications
 
@@ -478,11 +479,20 @@ The Claude Code CLI must be installed and authenticated:
 3. Verify: `claude --version` should show the version number.
 4. Restart Novel Engine — it re-checks on startup.
 
+### "Codex CLI not detected"
+
+The Codex CLI must be installed and authenticated before you select a Codex model:
+
+1. Install: `npm i -g @openai/codex`
+2. Authenticate: Run `codex login` in your terminal and follow the login flow.
+3. Verify: `codex --version` should show the version number.
+4. Open Settings > Providers and click **Re-check** under Codex CLI Status.
+
 ### Agent Not Responding
 
-- Check that the Claude CLI is still authenticated (run `claude` in a terminal).
-- Check your internet connection — the CLI needs to reach Anthropic's API.
-- Check the model — Opus may be temporarily unavailable; try switching to Sonnet in Settings.
+- Check that the selected CLI is still authenticated (run `claude` or `codex` in a terminal).
+- Check your internet connection — the selected provider needs to reach its API.
+- Check the model — if one provider is unavailable, try switching models in Settings.
 
 ### Slow Responses
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture — Novel Engine
 
-> Last updated: 2026-03-29
+> Last updated: 2026-04-26
 
-Electron + React 18 + TypeScript 5 + Tailwind v4 + Zustand + better-sqlite3 + Claude Code CLI + Pandoc
+Electron + React 18 + TypeScript 5 + Tailwind v4 + Zustand + better-sqlite3 + Claude Code CLI + Codex CLI + Pandoc
 
 See domain-specific docs:
 - [Domain](./DOMAIN.md) — Types, interfaces, constants
@@ -56,6 +56,9 @@ src/
 │   ├── claude-cli/
 │   │   ├── ClaudeCodeClient.ts              # Spawns `claude` process, streams NDJSON, lifecycle
 │   │   ├── StreamSessionTracker.ts          # Tracks active stream sessions for orphan recovery
+│   │   └── index.ts
+│   ├── codex-cli/
+│   │   ├── CodexCliClient.ts                # Spawns `codex exec --json`, streams JSONL, tracks changed files
 │   │   └── index.ts
 │   ├── pandoc/
 │   │   └── index.ts                         # Pandoc binary path resolution (dev vs packaged)
@@ -156,6 +159,7 @@ DatabaseService(dbPath)
 AgentService(agentsDir)
 FileSystemService(booksDir, userDataPath)
 ClaudeCodeClient(booksDir, db)
+CodexCliClient(booksDir, db)
 
 UsageService
 └── IDatabaseService (DatabaseService)
@@ -273,7 +277,7 @@ The renderer layer normally uses `import type` only from domain. However, **pure
 
 - `contextIsolation: true` — always
 - `nodeIntegration: false` — always
-- No API keys stored — Claude Code CLI handles its own authentication
+- No API keys stored for built-in CLI providers — Claude Code CLI and Codex CLI handle their own authentication
 - All renderer↔main communication through the preload bridge
 - Custom `novel-asset://` protocol for serving local files (cover images) to renderer
 
@@ -322,7 +326,7 @@ The renderer layer normally uses `import type` only from domain. However, **pure
 | Styling | Tailwind CSS | ^4.0.0 |
 | State | Zustand | ^5.0.0 |
 | Database | better-sqlite3 | ^11.0.0 |
-| AI Backend | Claude Code CLI | (system-installed) |
+| AI Backend | Claude Code CLI + Codex CLI | (system-installed) |
 | Build | Pandoc | (bundled binary) |
 | IDs | nanoid | 3 |
 | Markdown | marked | ^15.0.0 |

--- a/docs/architecture/DOMAIN.md
+++ b/docs/architecture/DOMAIN.md
@@ -1,6 +1,6 @@
 # Domain — Types, Interfaces, Constants
 
-> Last updated: 2026-03-28
+> Last updated: 2026-04-26
 
 Everything in `src/domain/`. Pure TypeScript declarations — zero imports from other layers.
 
@@ -87,7 +87,7 @@ Everything in `src/domain/`. Pure TypeScript declarations — zero imports from 
 | Type | Shape | Used By |
 |------|-------|---------|
 | `ProviderId` | `string` | ProviderConfig, IModelProvider, IProviderRegistry |
-| `ProviderType` | `'claude-cli' \| 'opencode-cli' \| 'openai-compatible'` | ProviderConfig, infrastructure |
+| `ProviderType` | `'claude-cli' \| 'codex-cli' \| 'opencode-cli' \| 'openai-compatible'` | ProviderConfig, infrastructure |
 | `ProviderCapability` | `'text-completion' \| 'tool-use' \| 'thinking' \| 'streaming'` | ProviderConfig, IModelProvider |
 | `ProviderStatus` | `'available' \| 'unavailable' \| 'unchecked' \| 'error'` | IProviderRegistry.checkProviderStatus |
 | `ProviderConfig` | `{ id, type, name, enabled, isBuiltIn, apiKey?, baseUrl?, models, defaultModel?, capabilities }` | Settings, ProviderRegistry |
@@ -97,7 +97,7 @@ Everything in `src/domain/`. Pure TypeScript declarations — zero imports from 
 
 | Type | Shape | Used By |
 |------|-------|---------|
-| `AppSettings` | `{ hasClaudeCli, model, maxTokens, enableThinking, thinkingBudget, overrideThinkingBudget, autoCollapseThinking, enableNotifications, theme, initialized, authorName, providers, activeProviderId, completedTours }` | SettingsService, SettingsView, tourStore |
+| `AppSettings` | `{ hasClaudeCli, hasCodexCli, model, maxTokens, enableThinking, thinkingBudget, overrideThinkingBudget, autoCollapseThinking, enableNotifications, theme, initialized, authorName, providers, activeProviderId, completedTours }` | SettingsService, SettingsView, tourStore |
 
 ### Token Usage
 
@@ -228,6 +228,7 @@ Implemented by: `SettingsService` (`src/infrastructure/settings/`)
 |--------|-----------|---------|
 | `load` | `() => Promise<AppSettings>` | Cached settings merged with defaults |
 | `detectClaudeCli` | `() => Promise<boolean>` | Runs `claude --version` |
+| `detectCodexCli` | `() => Promise<boolean>` | Runs `codex --version` |
 | `update` | `(partial: Partial<AppSettings>) => Promise<void>` | Writes + invalidates cache |
 
 ### IAgentService
@@ -598,8 +599,9 @@ Implemented by: `FindReplaceService` (`src/application/FindReplaceService.ts`)
 | `DEFAULT_SETTINGS` | `AppSettings` | Default values for all settings (includes `providers` and `activeProviderId`) |
 | `AVAILABLE_MODELS` | 2-element array | **(deprecated)** Opus 4 and Sonnet 4. Use `BUILT_IN_PROVIDER_CONFIGS[0].models` or `IProviderRegistry.listAllModels()` |
 | `CLAUDE_CLI_PROVIDER_ID` | `'claude-cli'` | Built-in Claude CLI provider ID |
+| `CODEX_CLI_PROVIDER_ID` | `'codex-cli'` | Built-in Codex CLI provider ID |
 | `OPENCODE_CLI_PROVIDER_ID` | `'opencode-cli'` | Reserved for future OpenCode CLI provider |
-| `BUILT_IN_PROVIDER_CONFIGS` | `ProviderConfig[]` (1 element) | Default Claude CLI provider with Opus 4 and Sonnet 4 models |
+| `BUILT_IN_PROVIDER_CONFIGS` | `ProviderConfig[]` (2 elements) | Default Claude CLI provider plus Codex CLI provider with GPT-5.2 Codex and GPT-5.1 Codex models |
 | `FILE_MANIFEST_KEYS` | 13-element array | Canonical file paths for context |
 | `VERITY_PHASE_FILES` | Partial record | Maps pipeline phases to Verity sub-prompt filenames |
 | `VERITY_AUDIT_MODEL` | `'claude-sonnet-4-20250514'` | Model for audit pass |

--- a/docs/architecture/INFRASTRUCTURE.md
+++ b/docs/architecture/INFRASTRUCTURE.md
@@ -1,6 +1,6 @@
 # Infrastructure — Implementations
 
-> Last updated: 2026-03-28 (SESSION-03)
+> Last updated: 2026-04-26
 
 Everything in `src/infrastructure/`. Implements domain interfaces using Node.js builtins and npm packages.
 
@@ -19,7 +19,8 @@ Key behavior:
 - Constructor takes `userDataPath: string`
 - In-memory cache invalidated on write
 - `detectClaudeCli()` runs `claude --version` with timeout
-- Settings merged with `DEFAULT_SETTINGS` on load (forward-compatible)
+- `detectCodexCli()` runs `codex --version` with timeout
+- Settings merged with `DEFAULT_SETTINGS` on load; built-in provider configs are merged by ID so existing settings pick up newly shipped built-ins
 
 ### database/ — SQLite Persistence
 
@@ -90,6 +91,23 @@ Key behavior:
 - `hasActiveProcesses()` / `hasActiveProcessesForBook()` for idle detection
 - EPIPE/ERR_STREAM_DESTROYED on stdin logged with diagnostic info (stdinBytes, writableFinished, writableEnded)
 - System prompt size guard: rejects prompts > 500KB with clear error before spawn
+
+### codex-cli/ — Codex CLI Client
+
+| File | Purpose |
+|------|---------|
+| `CodexCliClient.ts` | Implements `IModelProvider`. Spawns `codex exec --json`, translates JSONL events into `StreamEvent`, tracks active processes, persists stream events, and detects changed files by comparing the working directory before/after a run. |
+| `index.ts` | Barrel export |
+
+Key behavior:
+- Provider ID is `codex-cli`; capabilities are `text-completion`, `tool-use`, and `streaming`
+- Spawns `codex --ask-for-approval never exec --json --sandbox workspace-write --skip-git-repo-check --ephemeral --model <model> --cd <workingDir> --add-dir <booksDir>`
+- Feeds the agent system prompt and conversation transcript to stdin because Codex CLI has no Claude-style `--system-prompt` argument
+- Parses `thread.started`, `turn.started`, `item.started`, `item.completed`, `turn.completed`, and `error` JSONL events from stdout
+- Maps `item.completed` assistant text to text blocks and `turn.completed.usage` to final token usage
+- Ignores non-JSON stderr warnings unless the Codex process exits nonzero
+- `abortStream` sends SIGTERM, then SIGKILL after 2s grace period
+- `isAvailable()` caches `codex --version`
 
 ### providers/ — Model Provider Registry
 
@@ -263,6 +281,41 @@ CLI outputs NDJSON (one JSON object per line) to stdout. Events map to `StreamEv
 ### Orphan Recovery
 
 On startup, `ChatService.recoverOrphanedSessions()` checks `stream_sessions` for rows with `ended_at IS NULL`, marks them as `interrupted`, and exposes them to the UI.
+
+---
+
+## Codex CLI Integration
+
+### Invocation
+
+```
+codex --ask-for-approval never exec \
+      --json \
+      --sandbox workspace-write \
+      --skip-git-repo-check \
+      --ephemeral \
+      --model <model> \
+      --cd <workingDir> \
+      --add-dir <booksDir>
+```
+
+- Working directory is the explicit `workingDir`, the active book directory, or `booksDir`
+- System prompt and conversation transcript are combined into a single stdin prompt
+- `workspace-write` keeps Codex scoped to the book working directory plus `booksDir`
+- `--json` emits newline-delimited JSON events on stdout
+
+### Streaming Protocol
+
+| Codex Event | StreamEvent Type |
+|-------------|------------------|
+| `turn.started` | `status` |
+| `item.started` | `toolUse` when the item is tool-like |
+| `item.completed` with assistant text | `blockStart` → `textDelta` → `blockEnd` |
+| `item.completed` with tool-like item | `toolUse`, `toolDuration` |
+| `turn.completed` | Captures token usage for final `done` |
+| process close | `filesChanged` from directory diff, then `done` |
+
+Changed-file detection is filesystem based rather than Codex event-schema based, so agent-written files are still captured if Codex JSON item shapes change.
 
 ---
 

--- a/docs/architecture/IPC.md
+++ b/docs/architecture/IPC.md
@@ -1,6 +1,6 @@
 # IPC — Channels, Preload Bridge, Handler Registry
 
-> Last updated: 2026-03-28
+> Last updated: 2026-04-26
 
 Everything in `src/main/ipc/` and `src/preload/`. Thin adapter layer between application services and the renderer.
 
@@ -14,6 +14,7 @@ Everything in `src/main/ipc/` and `src/preload/`. Thin adapter layer between app
 |---------|-----------|---------|---------|
 | `settings:load` | invoke | `settingsService.load()` | `AppSettings` |
 | `settings:detectClaudeCli` | invoke | `settingsService.detectClaudeCli()` | `boolean` |
+| `settings:detectCodexCli` | invoke | `settingsService.detectCodexCli()` | `boolean` |
 | `settings:update` | invoke | `settingsService.update(partial)` + syncs `nativeTheme.themeSource` | `void` |
 | `settings:getAvailableModels` | invoke | `providerRegistry.listAllModels()` | `ModelInfo[]` |
 | `settings:saveAuthorProfile` | invoke | `fs.writeFile(profilePath, content)` | `void` |
@@ -288,6 +289,7 @@ window.novelEngine: {
   settings: {
     load(): Promise<AppSettings>
     detectClaudeCli(): Promise<boolean>
+    detectCodexCli(): Promise<boolean>
     update(partial: Partial<AppSettings>): Promise<void>
     saveAuthorProfile(content: string): Promise<void>
     loadAuthorProfile(): Promise<string>

--- a/docs/architecture/RENDERER.md
+++ b/docs/architecture/RENDERER.md
@@ -1,6 +1,6 @@
 # Renderer — Stores, Components, Views
 
-> Last updated: 2026-03-29
+> Last updated: 2026-04-26
 
 Everything in `src/renderer/`. React + Zustand UI layer. Talks to backend only through `window.novelEngine`.
 
@@ -69,6 +69,8 @@ File: `stores/settingsStore.ts`
 | Action | What It Does |
 |--------|-------------|
 | `load()` | Calls `window.novelEngine.settings.load()` |
+| `detectClaudeCli()` | Calls `settings.detectClaudeCli()`, reloads settings |
+| `detectCodexCli()` | Calls `settings.detectCodexCli()`, reloads settings |
 | `update(partial)` | Calls bridge, then reloads |
 
 ### bookStore
@@ -390,8 +392,8 @@ Gate: `App.tsx` checks `settings.initialized` — if false, renders `OnboardingW
 
 | File | Purpose |
 |------|---------|
-| `SettingsView.tsx` | Full settings panel: CLI status, providers, model selection (grouped by provider), thinking, theme, author profile, usage stats, catalog export |
-| `ProviderSection.tsx` | Provider management: cards with status dots, test connectivity, add/remove/toggle, "Add Provider" form |
+| `SettingsView.tsx` | Full settings panel: Claude CLI status, Codex CLI status, providers, model selection (grouped by provider), thinking, theme, author profile, usage stats, catalog export |
+| `ProviderSection.tsx` | Provider management: cards with status dots, provider type labels including `codex-cli`, test connectivity, add/remove/toggle, "Add Provider" form |
 
 ### Sidebar/
 

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -154,7 +154,7 @@ export const BUILT_IN_PROVIDER_CONFIGS: ProviderConfig[] = [
         description: 'OpenAI Codex model for long-running agentic writing tasks',
         providerId: CODEX_CLI_PROVIDER_ID,
         contextWindow: 400_000,
-        supportsThinking: true,
+        supportsThinking: false,
         supportsToolUse: true,
       },
       {
@@ -163,12 +163,12 @@ export const BUILT_IN_PROVIDER_CONFIGS: ProviderConfig[] = [
         description: 'OpenAI Codex model optimized for coding-agent style tool use',
         providerId: CODEX_CLI_PROVIDER_ID,
         contextWindow: 400_000,
-        supportsThinking: true,
+        supportsThinking: false,
         supportsToolUse: true,
       },
     ],
     defaultModel: 'gpt-5.2-codex',
-    capabilities: ['text-completion', 'tool-use', 'thinking', 'streaming'],
+    capabilities: ['text-completion', 'tool-use', 'streaming'],
   },
 ];
 

--- a/src/domain/constants.ts
+++ b/src/domain/constants.ts
@@ -104,6 +104,9 @@ export const AVAILABLE_MODELS = [
 /** The built-in Claude CLI provider ID. Always present, cannot be removed. */
 export const CLAUDE_CLI_PROVIDER_ID: ProviderId = 'claude-cli';
 
+/** The built-in Codex CLI provider ID. Always present, cannot be removed. */
+export const CODEX_CLI_PROVIDER_ID: ProviderId = 'codex-cli';
+
 /** Reserved provider ID for OpenCode CLI (future implementation). */
 export const OPENCODE_CLI_PROVIDER_ID: ProviderId = 'opencode-cli';
 
@@ -138,11 +141,41 @@ export const BUILT_IN_PROVIDER_CONFIGS: ProviderConfig[] = [
     defaultModel: 'claude-opus-4-20250514',
     capabilities: ['text-completion', 'tool-use', 'thinking', 'streaming'],
   },
+  {
+    id: CODEX_CLI_PROVIDER_ID,
+    type: 'codex-cli',
+    name: 'Codex CLI',
+    enabled: true,
+    isBuiltIn: true,
+    models: [
+      {
+        id: 'gpt-5.2-codex',
+        label: 'GPT-5.2 Codex',
+        description: 'OpenAI Codex model for long-running agentic writing tasks',
+        providerId: CODEX_CLI_PROVIDER_ID,
+        contextWindow: 400_000,
+        supportsThinking: true,
+        supportsToolUse: true,
+      },
+      {
+        id: 'gpt-5.1-codex',
+        label: 'GPT-5.1 Codex',
+        description: 'OpenAI Codex model optimized for coding-agent style tool use',
+        providerId: CODEX_CLI_PROVIDER_ID,
+        contextWindow: 400_000,
+        supportsThinking: true,
+        supportsToolUse: true,
+      },
+    ],
+    defaultModel: 'gpt-5.2-codex',
+    capabilities: ['text-completion', 'tool-use', 'thinking', 'streaming'],
+  },
 ];
 
 // Default settings
 export const DEFAULT_SETTINGS: AppSettings = {
   hasClaudeCli: false,
+  hasCodexCli: false,
   model: 'claude-sonnet-4-20250514',
   maxTokens: 8192,
   enableThinking: false,

--- a/src/domain/interfaces.ts
+++ b/src/domain/interfaces.ts
@@ -64,6 +64,7 @@ import type {
 export interface ISettingsService {
   load(): Promise<AppSettings>;
   detectClaudeCli(): Promise<boolean>;
+  detectCodexCli(): Promise<boolean>;
   update(partial: Partial<AppSettings>): Promise<void>;
 }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -262,7 +262,7 @@ export type ActiveStreamInfo = {
 export type ProviderId = string;
 
 /** The implementation strategy for a provider. Determines which infrastructure class is instantiated. */
-export type ProviderType = 'claude-cli' | 'opencode-cli' | 'openai-compatible';
+export type ProviderType = 'claude-cli' | 'codex-cli' | 'opencode-cli' | 'openai-compatible';
 
 /** Capabilities a provider may support. Used to gate features in the UI and services. */
 export type ProviderCapability =
@@ -313,6 +313,7 @@ export type SavedPrompt = {
 
 export type AppSettings = {
   hasClaudeCli: boolean;   // true if `claude` CLI is detected and authenticated
+  hasCodexCli: boolean;    // true if `codex` CLI is detected and authenticated
   model: string;
   maxTokens: number;
   enableThinking: boolean;

--- a/src/infrastructure/codex-cli/CodexCliClient.ts
+++ b/src/infrastructure/codex-cli/CodexCliClient.ts
@@ -1,0 +1,535 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { nanoid } from 'nanoid';
+
+import type { IDatabaseService, IModelProvider } from '@domain/interfaces';
+import type { FileTouchMap, MessageRole, ProviderCapability, ProviderId, StreamEvent } from '@domain/types';
+import { CHARS_PER_TOKEN, CODEX_CLI_PROVIDER_ID } from '@domain/constants';
+import { StreamSessionTracker } from '@infra/claude-cli/StreamSessionTracker';
+
+const execFileAsync = promisify(execFile);
+
+const CLI_NOT_FOUND_MESSAGE =
+  'Codex CLI not found. Install it with `npm i -g @openai/codex`, then run `codex login`.';
+
+const ABORT_KILL_GRACE_MS = 2000;
+const BATCH_FLUSH_INTERVAL_MS = 100;
+const BATCH_MAX_SIZE = 20;
+const CRITICAL_EVENT_TYPES = new Set(['done', 'error', 'callStart', 'filesChanged']);
+
+type EventRecord = {
+  sessionId: string;
+  conversationId: string;
+  sequenceNumber: number;
+  eventType: string;
+  payload: string;
+  timestamp: string;
+};
+
+type FileSnapshot = Record<string, { mtimeMs: number; size: number }>;
+
+type CodexUsage = {
+  inputTokens: number;
+  outputTokens: number;
+};
+
+export class CodexCliClient implements IModelProvider {
+  readonly providerId: ProviderId = CODEX_CLI_PROVIDER_ID;
+
+  readonly capabilities: ProviderCapability[] = [
+    'text-completion',
+    'tool-use',
+    'streaming',
+  ];
+
+  private _available: boolean | null = null;
+  private activeProcesses: Map<string, ChildProcess> = new Map();
+  private processBookMap: Map<string, string> = new Map();
+
+  constructor(
+    private booksDir: string,
+    private db: IDatabaseService,
+  ) {}
+
+  async isAvailable(): Promise<boolean> {
+    if (this._available !== null) return this._available;
+    try {
+      await execFileAsync('codex', ['--version'], { timeout: 10_000 });
+      this._available = true;
+      return true;
+    } catch {
+      this._available = false;
+      return false;
+    }
+  }
+
+  invalidateAvailabilityCache(): void {
+    this._available = null;
+  }
+
+  hasActiveProcesses(): boolean {
+    return this.activeProcesses.size > 0;
+  }
+
+  hasActiveProcessesForBook(bookSlug: string): boolean {
+    for (const slug of this.processBookMap.values()) {
+      if (slug === bookSlug) return true;
+    }
+    return false;
+  }
+
+  abortStream(conversationId: string): void {
+    const child = this.activeProcesses.get(conversationId);
+    if (!child) return;
+
+    this.activeProcesses.delete(conversationId);
+    this.processBookMap.delete(conversationId);
+    child.kill('SIGTERM');
+
+    const forceKillTimer = setTimeout(() => {
+      try {
+        if (!child.killed) {
+          child.kill('SIGKILL');
+        }
+      } catch {
+        // Process already exited.
+      }
+    }, ABORT_KILL_GRACE_MS);
+
+    child.once('close', () => {
+      clearTimeout(forceKillTimer);
+    });
+  }
+
+  async sendMessage(params: {
+    model: string;
+    systemPrompt: string;
+    messages: { role: MessageRole; content: string }[];
+    maxTokens: number;
+    thinkingBudget?: number;
+    maxTurns?: number;
+    bookSlug?: string;
+    workingDir?: string;
+    sessionId?: string;
+    conversationId?: string;
+    onEvent: (event: StreamEvent) => void;
+  }): Promise<void> {
+    const { model, bookSlug, workingDir } = params;
+    const sessionId = params.sessionId || nanoid();
+    const conversationId = params.conversationId ?? '';
+    const tracker = new StreamSessionTracker(sessionId);
+    const cwd = workingDir
+      ? workingDir
+      : bookSlug
+        ? path.join(this.booksDir, bookSlug)
+        : this.booksDir;
+
+    const beforeSnapshot = await this.snapshotDirectory(cwd);
+    let doneEmitted = false;
+    let finalUsage: CodexUsage = { inputTokens: 0, outputTokens: 0 };
+    let persistErrorLogged = false;
+    let eventBatch: EventRecord[] = [];
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const flushBatch = () => {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      if (eventBatch.length === 0) return;
+      const toFlush = eventBatch;
+      eventBatch = [];
+      try {
+        this.db.persistStreamEventBatch(toFlush);
+      } catch (err) {
+        if (!persistErrorLogged) {
+          console.error(`[CodexCliClient] Stream event batch persistence failed (conversationId=${conversationId}):`, err);
+          persistErrorLogged = true;
+        }
+      }
+    };
+
+    const wrappedOnEvent = (streamEvent: StreamEvent) => {
+      if (streamEvent.type === 'done') {
+        doneEmitted = true;
+      }
+
+      eventBatch.push({
+        sessionId,
+        conversationId,
+        sequenceNumber: tracker.nextSequence(),
+        eventType: streamEvent.type,
+        payload: JSON.stringify(streamEvent),
+        timestamp: new Date().toISOString(),
+      });
+
+      if (CRITICAL_EVENT_TYPES.has(streamEvent.type) || eventBatch.length >= BATCH_MAX_SIZE) {
+        flushBatch();
+      } else if (!flushTimer) {
+        flushTimer = setTimeout(flushBatch, BATCH_FLUSH_INTERVAL_MS);
+      }
+
+      params.onEvent(streamEvent);
+    };
+
+    const prompt = this.buildPrompt(params.systemPrompt, params.messages);
+    const args = [
+      '--ask-for-approval', 'never',
+      'exec',
+      '--json',
+      '--sandbox', 'workspace-write',
+      '--skip-git-repo-check',
+      '--ephemeral',
+      '--model', model,
+      '--cd', cwd,
+      '--add-dir', this.booksDir,
+    ];
+
+    console.log(`[CodexCliClient] Spawning CLI: model=${model}, cwd=${cwd}, conversationId=${conversationId}`);
+
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn('codex', args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env },
+        cwd,
+      });
+
+      if (conversationId) {
+        this.activeProcesses.set(conversationId, child);
+        if (bookSlug) {
+          this.processBookMap.set(conversationId, bookSlug);
+        }
+      }
+
+      let stdoutBuffer = '';
+      let stderrBuffer = '';
+      let settled = false;
+
+      const settle = (fn: () => void) => {
+        if (!settled) {
+          settled = true;
+          fn();
+        }
+      };
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        const message = err.code === 'ENOENT' ? CLI_NOT_FOUND_MESSAGE : err.message;
+        wrappedOnEvent({ type: 'error', message });
+        flushBatch();
+        settle(() => reject(new Error(message)));
+      });
+
+      const stdinBytes = Buffer.byteLength(prompt, 'utf-8');
+      child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EPIPE' || err.code === 'ERR_STREAM_DESTROYED') {
+          console.warn(
+            `[CodexCliClient] stdin ${err.code} — CLI process may have exited early ` +
+            `(conversationId=${conversationId}, stdinBytes=${stdinBytes})`,
+          );
+          return;
+        }
+        const message = `Codex CLI stdin error: ${err.message}`;
+        wrappedOnEvent({ type: 'error', message });
+        flushBatch();
+        settle(() => reject(new Error(message)));
+      });
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutBuffer += chunk.toString();
+        const lines = stdoutBuffer.split('\n');
+        stdoutBuffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const event = JSON.parse(line) as Record<string, unknown>;
+            const usage = this.processStreamEvent(event, tracker, wrappedOnEvent);
+            if (usage) finalUsage = usage;
+          } catch {
+            // Ignore non-JSON stdout lines defensively.
+          }
+        }
+      });
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrBuffer += chunk.toString();
+      });
+
+      child.on('close', (code) => {
+        void (async () => {
+          flushBatch();
+
+          if (conversationId) {
+            this.activeProcesses.delete(conversationId);
+            this.processBookMap.delete(conversationId);
+          }
+
+          if (stdoutBuffer.trim()) {
+            try {
+              const event = JSON.parse(stdoutBuffer.trim()) as Record<string, unknown>;
+              const usage = this.processStreamEvent(event, tracker, wrappedOnEvent);
+              if (usage) finalUsage = usage;
+            } catch {
+              // Ignore unparseable remainder.
+            }
+          }
+
+          const fileTouches = await this.collectFileTouches(cwd, beforeSnapshot);
+          const touchedPaths = Object.keys(fileTouches);
+          for (const touchedPath of touchedPaths) {
+            tracker.touchFile(touchedPath);
+          }
+
+          if (touchedPaths.length > 0) {
+            wrappedOnEvent({ type: 'filesChanged', paths: touchedPaths });
+          }
+
+          if (code === 0) {
+            if (!doneEmitted) {
+              const stageChange = tracker.inferStage('result');
+              if (stageChange) {
+                wrappedOnEvent({ type: 'progressStage', stage: stageChange });
+              }
+              wrappedOnEvent({
+                type: 'done',
+                inputTokens: finalUsage.inputTokens,
+                outputTokens: finalUsage.outputTokens,
+                thinkingTokens: Math.ceil(tracker.getThinkingBuffer().length / CHARS_PER_TOKEN),
+                filesTouched: tracker.getFileTouches(),
+              });
+            }
+            flushBatch();
+            settle(() => resolve());
+          } else {
+            const message = stderrBuffer.trim() || `Codex CLI exited with code ${code}`;
+            wrappedOnEvent({ type: 'error', message });
+            flushBatch();
+            settle(() => reject(new Error(message)));
+          }
+        })().catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          wrappedOnEvent({ type: 'error', message });
+          flushBatch();
+          settle(() => reject(new Error(message)));
+        });
+      });
+
+      child.stdin.write(prompt);
+      child.stdin.end();
+    });
+  }
+
+  private buildPrompt(systemPrompt: string, messages: { role: MessageRole; content: string }[]): string {
+    return [
+      'You are running inside Novel Engine as an autonomous writing-production agent.',
+      'Follow the system prompt below exactly. Read and write files relative to the current working directory unless an absolute path is provided.',
+      '',
+      '<system_prompt>',
+      systemPrompt,
+      '</system_prompt>',
+      '',
+      '<conversation>',
+      this.buildConversationPrompt(messages),
+      '</conversation>',
+    ].join('\n');
+  }
+
+  private buildConversationPrompt(messages: { role: MessageRole; content: string }[]): string {
+    if (messages.length === 0) return '';
+    if (messages.length === 1) return `Human: ${messages[0].content}`;
+
+    const parts: string[] = [];
+    for (const msg of messages) {
+      const roleLabel = msg.role === 'user' ? 'Human' : 'Assistant';
+      parts.push(`${roleLabel}: ${msg.content}`);
+    }
+    return parts.join('\n\n');
+  }
+
+  private processStreamEvent(
+    event: Record<string, unknown>,
+    tracker: StreamSessionTracker,
+    onEvent: (event: StreamEvent) => void,
+  ): CodexUsage | null {
+    const eventType = event.type as string;
+
+    if (eventType === 'turn.started') {
+      onEvent({ type: 'status', message: 'Codex started' });
+      return null;
+    }
+
+    if (eventType === 'item.started') {
+      this.emitToolEvent(event.item as Record<string, unknown> | undefined, tracker, onEvent, 'started');
+      return null;
+    }
+
+    if (eventType === 'item.completed') {
+      const item = event.item as Record<string, unknown> | undefined;
+      if (!item) return null;
+
+      const text = this.extractText(item);
+      if (text) {
+        const needsSeparator = tracker.getHasEmittedText();
+        tracker.markTextEmitted();
+        onEvent({ type: 'blockStart', blockType: 'text' });
+        if (needsSeparator) {
+          onEvent({ type: 'textDelta', text: '\n\n' });
+        }
+        onEvent({ type: 'textDelta', text });
+        onEvent({ type: 'blockEnd', blockType: 'text' });
+        return null;
+      }
+
+      this.emitToolEvent(item, tracker, onEvent, 'complete');
+      return null;
+    }
+
+    if (eventType === 'turn.completed') {
+      const usage = event.usage as Record<string, number> | undefined;
+      return {
+        inputTokens: usage?.input_tokens ?? 0,
+        outputTokens: usage?.output_tokens ?? 0,
+      };
+    }
+
+    if (eventType === 'error') {
+      const message = String(event.message ?? 'Codex CLI error');
+      onEvent({ type: 'error', message });
+      return null;
+    }
+
+    return null;
+  }
+
+  private extractText(item: Record<string, unknown>): string {
+    if (typeof item.text === 'string') return item.text;
+    if (typeof item.message === 'string') return item.message;
+    if (typeof item.content === 'string') return item.content;
+
+    const content = item.content;
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (!part || typeof part !== 'object') return '';
+          const record = part as Record<string, unknown>;
+          return typeof record.text === 'string' ? record.text : '';
+        })
+        .filter(Boolean)
+        .join('');
+    }
+
+    return '';
+  }
+
+  private emitToolEvent(
+    item: Record<string, unknown> | undefined,
+    tracker: StreamSessionTracker,
+    onEvent: (event: StreamEvent) => void,
+    status: 'started' | 'complete',
+  ): void {
+    if (!item) return;
+    const itemType = String(item.type ?? '');
+    const toolName = this.resolveToolName(item);
+    if (!toolName && !itemType.includes('tool') && !itemType.includes('command')) return;
+
+    const toolId = String(item.id ?? item.call_id ?? nanoid());
+    const filePath = this.extractFilePath(item);
+    const resolvedToolName = toolName || itemType || 'tool';
+
+    if (status === 'started') {
+      tracker.startTool(toolId);
+      tracker.setCurrentToolName(resolvedToolName);
+      tracker.setCurrentToolId(toolId);
+    }
+
+    if (status === 'complete' && filePath && this.isWriteLikeTool(resolvedToolName)) {
+      tracker.touchFile(filePath);
+    }
+
+    const toolInfo = {
+      toolName: resolvedToolName,
+      toolId,
+      filePath,
+      status,
+    };
+
+    onEvent({ type: 'toolUse', tool: toolInfo });
+    const timestamped = status === 'complete' ? tracker.endTool(toolInfo) : null;
+    if (timestamped) {
+      onEvent({ type: 'toolDuration', tool: timestamped });
+    }
+
+    const stageChange = tracker.inferStage('toolUse', resolvedToolName, filePath);
+    if (stageChange) {
+      onEvent({ type: 'progressStage', stage: stageChange });
+    }
+  }
+
+  private resolveToolName(item: Record<string, unknown>): string {
+    const rawName = item.name ?? item.tool_name ?? item.command;
+    if (typeof rawName === 'string' && rawName.trim()) {
+      return rawName.includes(' ') ? 'Shell' : rawName;
+    }
+    return '';
+  }
+
+  private extractFilePath(item: Record<string, unknown>): string | undefined {
+    const input = item.input as Record<string, unknown> | undefined;
+    const candidates = [
+      item.file_path,
+      item.path,
+      input?.file_path,
+      input?.path,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+
+  private isWriteLikeTool(toolName: string): boolean {
+    const normalized = toolName.toLowerCase();
+    return normalized.includes('write') || normalized.includes('edit') || normalized.includes('patch');
+  }
+
+  private async snapshotDirectory(root: string): Promise<FileSnapshot> {
+    const snapshot: FileSnapshot = {};
+    await this.walkFiles(root, root, snapshot).catch(() => {});
+    return snapshot;
+  }
+
+  private async collectFileTouches(root: string, before: FileSnapshot): Promise<FileTouchMap> {
+    const after = await this.snapshotDirectory(root);
+    const touched: FileTouchMap = {};
+
+    for (const [relativePath, afterInfo] of Object.entries(after)) {
+      const beforeInfo = before[relativePath];
+      if (!beforeInfo || beforeInfo.mtimeMs !== afterInfo.mtimeMs || beforeInfo.size !== afterInfo.size) {
+        touched[relativePath] = 1;
+      }
+    }
+
+    return touched;
+  }
+
+  private async walkFiles(root: string, current: string, snapshot: FileSnapshot): Promise<void> {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await this.walkFiles(root, absolutePath, snapshot);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const info = await stat(absolutePath);
+      const relativePath = path.relative(root, absolutePath).split(path.sep).join('/');
+      snapshot[relativePath] = { mtimeMs: info.mtimeMs, size: info.size };
+    }
+  }
+}

--- a/src/infrastructure/codex-cli/index.ts
+++ b/src/infrastructure/codex-cli/index.ts
@@ -1,0 +1,1 @@
+export { CodexCliClient } from './CodexCliClient';

--- a/src/infrastructure/settings/SettingsService.ts
+++ b/src/infrastructure/settings/SettingsService.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 
 import type { AppSettings } from '@domain/types';
 import type { ISettingsService } from '@domain/interfaces';
-import { DEFAULT_SETTINGS } from '@domain/constants';
+import { BUILT_IN_PROVIDER_CONFIGS, DEFAULT_SETTINGS } from '@domain/constants';
 
 const execFile = promisify(execFileCb);
 
@@ -23,7 +23,11 @@ export class SettingsService implements ISettingsService {
     try {
       const raw = await readFile(this.settingsPath, 'utf-8');
       const stored: Partial<AppSettings> = JSON.parse(raw);
-      this._cache = { ...DEFAULT_SETTINGS, ...stored };
+      this._cache = {
+        ...DEFAULT_SETTINGS,
+        ...stored,
+        providers: this.mergeProviderConfigs(stored.providers),
+      };
       return this._cache;
     } catch {
       // ENOENT or malformed JSON — use defaults for first launch
@@ -53,5 +57,31 @@ export class SettingsService implements ISettingsService {
       await this.update({ hasClaudeCli: false });
       return false;
     }
+  }
+
+  async detectCodexCli(): Promise<boolean> {
+    try {
+      const { stdout } = await execFile('codex', ['--version'], { timeout: 10_000 });
+      const found = stdout.trim().length > 0;
+      await this.update({ hasCodexCli: found });
+      return found;
+    } catch {
+      await this.update({ hasCodexCli: false });
+      return false;
+    }
+  }
+
+  private mergeProviderConfigs(storedProviders: AppSettings['providers'] | undefined): AppSettings['providers'] {
+    const providersById = new Map<string, AppSettings['providers'][number]>();
+    for (const provider of storedProviders ?? []) {
+      providersById.set(provider.id, provider);
+    }
+
+    for (const builtInProvider of BUILT_IN_PROVIDER_CONFIGS) {
+      const stored = providersById.get(builtInProvider.id);
+      providersById.set(builtInProvider.id, stored ? { ...builtInProvider, ...stored, isBuiltIn: true } : builtInProvider);
+    }
+
+    return Array.from(providersById.values());
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,10 +54,11 @@ import { DatabaseService } from '@infra/database';
 import { AgentService } from '@infra/agents';
 import { FileSystemService, BookWatcher, BooksDirWatcher } from '@infra/filesystem';
 import { ClaudeCodeClient } from '@infra/claude-cli';
+import { CodexCliClient } from '@infra/codex-cli';
 import { ProviderRegistry, OpenAiCompatibleProvider } from '@infra/providers';
 import { resolvePandocPath } from '@infra/pandoc';
 import { SeriesService } from '@infra/series';
-import { BUILT_IN_PROVIDER_CONFIGS } from '@domain/constants';
+import { BUILT_IN_PROVIDER_CONFIGS, CLAUDE_CLI_PROVIDER_ID, CODEX_CLI_PROVIDER_ID } from '@domain/constants';
 
 // Application
 import { AuditService } from '@app/AuditService';
@@ -226,21 +227,32 @@ async function initializeApp(): Promise<void> {
   const agents = new AgentService(agentsDir);
   const fs = new FileSystemService(booksDir, userDataPath);
   const claudeClient = new ClaudeCodeClient(booksDir, db);
+  const codexClient = new CodexCliClient(booksDir, db);
 
   // 3b. Initialize provider registry
   const providerRegistry = new ProviderRegistry(settings);
 
   // Register the built-in Claude CLI provider
   const appSettings = await settings.load();
-  const claudeConfig = appSettings.providers.find(p => p.id === 'claude-cli');
+  const claudeConfig = appSettings.providers.find(p => p.id === CLAUDE_CLI_PROVIDER_ID);
   providerRegistry.registerProvider(
     claudeClient,
     claudeConfig ?? BUILT_IN_PROVIDER_CONFIGS[0],
   );
 
+  // Register the built-in Codex CLI provider
+  const codexConfig = appSettings.providers.find(p => p.id === CODEX_CLI_PROVIDER_ID);
+  const builtInCodexConfig = BUILT_IN_PROVIDER_CONFIGS.find(p => p.id === CODEX_CLI_PROVIDER_ID);
+  if (builtInCodexConfig) {
+    providerRegistry.registerProvider(
+      codexClient,
+      codexConfig ?? builtInCodexConfig,
+    );
+  }
+
   // Initialize user-configured providers from settings
   for (const config of appSettings.providers) {
-    if (config.id === 'claude-cli') continue;
+    if (config.isBuiltIn) continue;
     if (!config.enabled) continue;
 
     if (config.type === 'openai-compatible') {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -104,6 +104,8 @@ export function registerIpcHandlers(services: {
 
   ipcMain.handle('settings:detectClaudeCli', () => services.settings.detectClaudeCli());
 
+  ipcMain.handle('settings:detectCodexCli', () => services.settings.detectCodexCli());
+
   ipcMain.handle('settings:update', async (_, partial: Partial<AppSettings>) => {
     await services.settings.update(partial);
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -59,6 +59,7 @@ const api = {
   settings: {
     load: (): Promise<AppSettings> => ipcRenderer.invoke('settings:load'),
     detectClaudeCli: (): Promise<boolean> => ipcRenderer.invoke('settings:detectClaudeCli'),
+    detectCodexCli: (): Promise<boolean> => ipcRenderer.invoke('settings:detectCodexCli'),
     update: (partial: Partial<AppSettings>): Promise<void> => ipcRenderer.invoke('settings:update', partial),
     saveAuthorProfile: (content: string): Promise<void> =>
       ipcRenderer.invoke('settings:saveAuthorProfile', content),

--- a/src/renderer/components/Settings/ProviderSection.tsx
+++ b/src/renderer/components/Settings/ProviderSection.tsx
@@ -13,6 +13,7 @@ function StatusDot({ status }: { status: ProviderStatus | undefined }): React.Re
 
 function TypeBadge({ type }: { type: string }): React.ReactElement {
   const label = type === 'claude-cli' ? 'Claude CLI' :
+    type === 'codex-cli' ? 'Codex CLI' :
     type === 'openai-compatible' ? 'OpenAI Compatible' :
     type;
   return (
@@ -233,7 +234,7 @@ export function ProviderSection(): React.ReactElement {
     <section className="space-y-3">
       <h3 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">Model Providers</h3>
       <p className="text-sm text-zinc-500">
-        Configure AI model providers. Claude CLI is the primary provider with full tool-use support. Add OpenAI-compatible providers for BYOK or self-hosted models (text only).
+        Configure AI model providers. Claude CLI and Codex CLI support local tool-use workflows. Add OpenAI-compatible providers for BYOK or self-hosted models (text only).
       </p>
       <div className="space-y-3">
         {providers.map((config) => (

--- a/src/renderer/components/Settings/SettingsView.tsx
+++ b/src/renderer/components/Settings/SettingsView.tsx
@@ -69,6 +69,54 @@ function ClaudeCliSection(): React.ReactElement {
   );
 }
 
+function CodexCliSection(): React.ReactElement {
+  const { settings, detectCodexCli } = useSettingsStore();
+  const [checking, setChecking] = useState(false);
+
+  const handleRecheck = useCallback(async () => {
+    setChecking(true);
+    await detectCodexCli();
+    setChecking(false);
+  }, [detectCodexCli]);
+
+  const connected = settings?.hasCodexCli ?? false;
+
+  return (
+    <section className="space-y-3">
+      <SectionHeading>Codex CLI Status</SectionHeading>
+      <div className="flex items-center gap-3">
+        <span
+          className={`h-3 w-3 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'}`}
+        />
+        <span className={`text-sm font-medium ${connected ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          {connected ? 'Connected' : 'Not connected'}
+        </span>
+        <button
+          onClick={handleRecheck}
+          disabled={checking}
+          className="ml-auto rounded-md border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-700 dark:text-zinc-300 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700 disabled:opacity-50"
+        >
+          {checking ? 'Checking...' : 'Re-check'}
+        </button>
+      </div>
+      {!connected && (
+        <div className="mt-2">
+          <button
+            onClick={() =>
+              window.novelEngine.shell.openExternal(
+                'https://developers.openai.com/codex/cli',
+              )
+            }
+            className="text-sm text-blue-600 dark:text-blue-400 underline decoration-blue-600/30 dark:decoration-blue-400/30 transition-colors hover:text-blue-600 dark:hover:text-blue-300"
+          >
+            Installation instructions
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function ModelSelectionSection(): React.ReactElement {
   const { settings, update } = useSettingsStore();
   const { providers } = useProviderStore();
@@ -142,7 +190,7 @@ function ModelSelectionSection(): React.ReactElement {
                     )}
                   </div>
                   <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{model.label}</span>
-                  {model.id === 'claude-opus-4-20250514' && (
+                  {(model.id === 'claude-opus-4-20250514' || model.id === 'gpt-5.2-codex') && (
                     <span className="rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
                       Recommended
                     </span>
@@ -588,7 +636,7 @@ function AboutSection(): React.ReactElement {
         <p className="text-sm text-zinc-700 dark:text-zinc-300">
           <span className="font-medium">Novel Engine</span> v0.1.0
         </p>
-        <HelpText>Powered by Claude Code CLI</HelpText>
+        <HelpText>Powered by Claude Code CLI and Codex CLI</HelpText>
         <div className="flex gap-4">
           <button
             onClick={() =>
@@ -609,6 +657,16 @@ function AboutSection(): React.ReactElement {
             className="text-sm text-blue-600 dark:text-blue-400 underline decoration-blue-600/30 dark:decoration-blue-400/30 transition-colors hover:text-blue-600 dark:hover:text-blue-300"
           >
             Claude Code Docs
+          </button>
+          <button
+            onClick={() =>
+              window.novelEngine.shell.openExternal(
+                'https://developers.openai.com/codex/cli',
+              )
+            }
+            className="text-sm text-blue-600 dark:text-blue-400 underline decoration-blue-600/30 dark:decoration-blue-400/30 transition-colors hover:text-blue-600 dark:hover:text-blue-300"
+          >
+            Codex CLI Docs
           </button>
         </div>
       </div>
@@ -711,6 +769,8 @@ export function SettingsView(): React.ReactElement {
           {activeTab === 'providers' && (
             <>
               <ClaudeCliSection />
+              <SectionDivider />
+              <CodexCliSection />
               <SectionDivider />
               <ProviderSection />
             </>

--- a/src/renderer/stores/settingsStore.ts
+++ b/src/renderer/stores/settingsStore.ts
@@ -6,6 +6,7 @@ type SettingsState = {
   loading: boolean;
   load: () => Promise<void>;
   detectClaudeCli: () => Promise<boolean>;
+  detectCodexCli: () => Promise<boolean>;
   update: (partial: Partial<AppSettings>) => Promise<void>;
 };
 
@@ -33,6 +34,18 @@ export const useSettingsStore = create<SettingsState>((set) => ({
       return found;
     } catch (error) {
       console.error('Failed to detect Claude CLI:', error);
+      return false;
+    }
+  },
+
+  detectCodexCli: async () => {
+    try {
+      const found = await window.novelEngine.settings.detectCodexCli();
+      const settings = await window.novelEngine.settings.load();
+      set({ settings });
+      return found;
+    } catch (error) {
+      console.error('Failed to detect Codex CLI:', error);
       return false;
     }
   },


### PR DESCRIPTION
## Summary
- add Codex CLI as a built-in local tool-use provider alongside Claude CLI
- add Codex CLI detection, settings UI status, provider metadata, and model routing
- implement a Codex JSONL runner that maps codex exec events into Novel Engine stream events and tracks changed files
- update README, user guide, changelog, and architecture docs

## Verification
- npm install --ignore-scripts
- npm run lint

## Notes
- Full npm install failed on this Windows machine because better-sqlite3 had no Node 24 prebuilt binary and the Visual Studio ClangCL toolset is not installed. Typecheck was verified after installing dependencies with lifecycle scripts disabled.